### PR TITLE
Change ROSS invite link to land in #rojo and add warning

### DIFF
--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -8,7 +8,9 @@ Rojo is a fairly complex tool to adopt, but there's a community willing to help!
 The [Roblox Open Source Community Discord](https://discord.gg/uhNRWm2sx5) currently hosts a Rojo support channel, **#rojo**, that is a great place to get help as problems come up.
 
 :::warning
-**Do not request Rojo support in #general.** Questions about Rojo should be kept in #rojo, as we do not wish to pollute other channels with Rojo chatter.
+**Do not request Rojo support in #general.**
+
+Questions about Rojo should be kept in #rojo, as we do not wish to pollute other channels with Rojo chatter.
 :::
 
 If you find anything that looks like a bug or have ideas for how to improve Rojo, feel free to file an issue on [Rojo's GitHub issue tracker](https://github.com/rojo-rbx/rojo/issues).


### PR DESCRIPTION
This PR changes the Roblox Open Source Software Discord server link to one that lands users in the #rojo channel, hopefully reducing the number of users who post Rojo questions in unrelated channels.

It also adds a warning against the most probable failure mode, which is a user posting such questions in the general channel.

I generated this invite link myself. It has no expiry, and should land users in #rojo. However, I have not yet tested this link on a fresh Discord account, and I am not sure if users will still land in #rojo after the ROSS server's onboarding flow. Help with this is much appreciated!