### PR TITLE
Clicking heading hash link copies link to keyboard

### DIFF
--- a/src/theme/Heading/index.js
+++ b/src/theme/Heading/index.js
@@ -1,0 +1,27 @@
+import Heading from '@theme-original/Heading';
+
+export default function HeadingWrapper(props) {
+  const handleClick = async (e) => {
+    const target = e.target;
+
+    if (target.classList.contains('hash-link')) {
+
+      const href = target.getAttribute('href');
+      if (!href) return;
+
+      const url = `${window.location.origin}${window.location.pathname}${href}`;
+
+      try {
+        await navigator.clipboard.writeText(url);
+      } catch (err) {
+        console.error('Clipboard copy failed', err);
+      }
+    }
+  };
+
+  return (
+    <div onClick={handleClick}>
+      <Heading {...props} />
+    </div>
+  );
+}


### PR DESCRIPTION
A small Quality of Life change, using docusaurus swizzle it adds copying to the heading click link.

As the only use for these links is to get the section url, they should copy straight to clipboard rather than requiring two additional steps.
<img width="558" height="177" alt="image" src="https://github.com/user-attachments/assets/5d04d53b-7ccf-4ac8-a500-46b6e0ca9844" />
