### PR TITLE
Change default install instructions to use Rokit

### DIFF
--- a/docs/getting-started/installation.mdx
+++ b/docs/getting-started/installation.mdx
@@ -12,7 +12,7 @@ import Link from "@docusaurus/Link";
 There are two supported ways to install Rojo:
 
 <Tabs groupId="installation-kind">
-<TabItem value="vscode" label="VS Code" default>
+<TabItem value="vscode" label="VS Code">
 
 If you use Visual Studio Code, you can install [the Rojo VS Code extension][extension], which allows for both halves of Rojo to work within Visual Studio Code, with a nifty UI to sync files and start/stop the Rojo server!
 
@@ -23,7 +23,7 @@ The VS Code extension does not add `rojo` to your system PATH. In order to use R
 [extension]: https://marketplace.visualstudio.com/items?itemName=evaera.vscode-rojo
 
 </TabItem>
-<TabItem value="cli" label="CLI">
+<TabItem value="cli" label="CLI" default>
 
 Rojo has two pieces that need to be installed:
 

--- a/docs/getting-started/new-game.mdx
+++ b/docs/getting-started/new-game.mdx
@@ -11,7 +11,7 @@ import TabItem from "@theme/TabItem";
 Rojo has a built-in command to initialize a new game project.
 
 <Tabs groupId="installation-kind">
-<TabItem value="vscode" label="VS Code" default>
+<TabItem value="vscode" label="VS Code">
 
 Open a new empty folder in VS Code. Your editor should look like this:
 
@@ -33,7 +33,7 @@ Once it succeeds, you should see a bunch of new files:
 These are all the files you need to get started with Rojo.
 
 </TabItem>
-<TabItem value="cli" label="CLI">
+<TabItem value="cli" label="CLI" default>
 
 First, open up a terminal window, like `cmd.exe` on Windows or `Terminal.app` on macOS. Navigate to where you'd like to store your new project and run
 
@@ -51,7 +51,7 @@ Rojo will create a folder named `my-new-game` if it doesn't already exist and cr
 Now that we have a project, one thing we can do is build a Roblox place file for our project. This is a great way to get started with a project quickly with no fuss.
 
 <Tabs groupId="installation-kind">
-<TabItem value="vscode" label="VS Code" default>
+<TabItem value="vscode" label="VS Code">
 
 Open your VS Code Command Palette (`ctrl+shift+P` on Windows, `cmd+shift+P` on macOS) and type `Rojo: Open Menu`. Run the command that pops up:
 
@@ -62,7 +62,7 @@ Click the `Build project` button.
 ![rojo build from menu](/img/vscode/build-command.png)
 
 </TabItem>
-<TabItem value="cli" label="CLI">
+<TabItem value="cli" label="CLI" default>
 
 All we have to do is run `rojo build` from inside the project's folder:
 
@@ -90,7 +90,7 @@ In Roblox Studio, make sure the Rojo plugin is installed. If you need it, check 
 To expose your project to the plugin, you'll need to start the **live sync server**.
 
 <Tabs groupId="installation-kind">
-<TabItem value="vscode" label="VS Code" default>
+<TabItem value="vscode" label="VS Code">
 
 Open your VS Code Command Palette (`ctrl+shift+P` on Windows, `cmd+shift+P` on macOS) and type `Rojo: Open Menu`. Run the command that pops up:
 
@@ -105,7 +105,7 @@ You should see a small popup in the bottom right corner of your screen with a fe
 ![rojo serve output](/img/vscode/serve-output.png)
 
 </TabItem>
-<TabItem value="cli" label="CLI">
+<TabItem value="cli" label="CLI" default>
 
 ```sh
 rojo serve
@@ -148,12 +148,12 @@ It's recommended that you set up a Roblox account dedicated to deploying your ga
 Generating and publishing your game is as simple as:
 
 <Tabs groupId="installation-kind">
-<TabItem value="vscode" label="VS Code" default>
+<TabItem value="vscode" label="VS Code">
 
 Uploading places is not yet supported in the Rojo VS Code Extension. You can publish your game using Roblox Studio or use the Rojo CLI instead.
 
 </TabItem>
-<TabItem value="cli" label="CLI">
+<TabItem value="cli" label="CLI" default>
 
 ```sh
 rojo upload --asset_id [PLACE ID] --cookie "[SECURITY COOKIE]"


### PR DESCRIPTION
With the vscode extension heavily out of date, and incapable of handling pre-releases (conflicting with the roblox library plugin), many users have issues which ultimately result in suggestions to just swap to Rokit.

Changing to suggesting Rokit by default saves time for both members of the OSS channel, and new users exploring the tooling.